### PR TITLE
Clean up fix 2 Ce terms and move orphans under all stages Ce May 20 2019

### DIFF
--- a/src/ontology/wbls-edit.owl
+++ b/src/ontology/wbls-edit.owl
@@ -1,21 +1,18 @@
-Prefix(:=<http://purl.obolibrary.org/obo/wbls.owl#>)
+Prefix(:=<http://purl.obolibrary.org/obo/wbls.owl/>)
+Prefix(dce:=<http://purl.org/dc/elements/1.1/>)
 Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
 Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
 Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
 Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
 Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
-Prefix(dce:=<http://purl.org/dc/elements/1.1/>)
 Prefix(dcterms:=<http://purl.org/dc/terms/>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/wbls.owl>
-
 Import(<http://purl.obolibrary.org/obo/wbls/imports/ro_import.owl>)
-
+Annotation(dce:description "Ontology about the development and life stages of the C. elegans")
 Annotation(dce:title "C. elegans Development Ontology")
 Annotation(dcterms:license "CC-BY")
-Annotation(dce:description "Ontology about the development and life stages of the C. elegans")
-
 Annotation(<http://www.geneontology.org/formats/oboInOwl#auto-generated-by> "OBO-Edit 2.2-rc1"^^xsd:string)
 Annotation(<http://www.geneontology.org/formats/oboInOwl#date> "15:11:2017 12:24"^^xsd:string)
 Annotation(<http://www.geneontology.org/formats/oboInOwl#default-namespace> "worm_development"^^xsd:string)
@@ -782,6 +779,9 @@ Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0002087>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000115>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0000231>))
 Declaration(AnnotationProperty(<http://purl.obolibrary.org/obo/IAO_0100001>))
+Declaration(AnnotationProperty(dce:description))
+Declaration(AnnotationProperty(dce:title))
+Declaration(AnnotationProperty(dcterms:license))
 Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#auto-generated-by>))
 Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#created_by>))
 Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#creation_date>))
@@ -920,6 +920,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000004> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000004> "WBls:0000004"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000004> "proliferating embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000004> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000004> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000003>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000005> (blastula embryo Ce)
@@ -929,6 +930,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000005> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000005> "WBls:0000005"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000005> "blastula embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000005> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000005> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000004>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000006> (1-cell embryo Ce)
@@ -939,6 +941,7 @@ AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#has
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000006> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000006> "WBls:0000006"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000006> "1-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000006> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000669>))
 
@@ -949,6 +952,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000007> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000007> "WBls:0000007"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000007> "2-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000007> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000007> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000007> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000006>))
 
@@ -959,6 +963,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000008> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000008> "WBls:0000008"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000008> "4-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000008> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000008> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000008> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000007>))
 
@@ -969,6 +974,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000009> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000009> "WBls:0000009"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000009> "28-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000009> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000009> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000010> (gastrulating embryo Ce)
@@ -978,6 +984,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000010> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000010> "WBls:0000010"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000010> "gastrulating embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000010> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000010> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000004>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000010> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000005>))
 
@@ -988,6 +995,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000011> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000011> "WBls:0000011"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000011> "51-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000011> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000011> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000011> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000086>))
 
@@ -998,6 +1006,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000012> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000012> "WBls:0000012"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000012> "88-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000012> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000012> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000012> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000088>))
 
@@ -1008,6 +1017,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000013> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000013> "WBls:0000013"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000013> "enclosing embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000013> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000014>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000014>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000010>))
@@ -1019,6 +1029,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000014> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000014> "WBls:0000014"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000014> "late cleavage stage embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000014> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000014> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000004>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000014> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000010>))
 
@@ -1030,6 +1041,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000015> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000015> "WBls:0000015"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000015> "elongating embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000015> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000003>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000015> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000004>))
@@ -1041,6 +1053,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000016> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000016> "WBls:0000016"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000016> "bean embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000016> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000016> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000016> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000016> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000014>))
@@ -1052,6 +1065,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000017> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000017> "WBls:0000017"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000017> "comma embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000017> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000016>))
 
@@ -1062,6 +1076,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000018> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000018> "WBls:0000018"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000018> "1.5-fold embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000018> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000018> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000018> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000017>))
 
@@ -1072,6 +1087,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000019> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000019> "WBls:0000019"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000019> "2-fold embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000019> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000019> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000019> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000018>))
 
@@ -1082,6 +1098,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000020> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000020> "WBls:0000020"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000020> "3-fold embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000020> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000020> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000020> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000019>))
 
@@ -1095,6 +1112,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000021> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000021> "WBls:0000021"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000021> "fully-elongated embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000021> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000021> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000003>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000021> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000021> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000020>))
@@ -1139,6 +1157,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000025> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000025> "WBls:0000025"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000025> "L1-L2 lethargus Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000025> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000026>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000026> (L1-L2 molt Ce)
@@ -1148,6 +1167,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000026> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000026> "WBls:0000026"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000026> "L1-L2 molt Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000026> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000026> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000023>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000026> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000024>))
 
@@ -1170,6 +1190,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000028> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000028> "WBls:0000028"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000028> "L2-L3 lethargus Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000028> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000028> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000029>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000029> (L2-L3 molt Ce)
@@ -1179,6 +1200,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000029> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000029> "WBls:0000029"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000029> "L2-L3 molt Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000029> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000029> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000023>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000029> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000027>))
 
@@ -1189,6 +1211,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000030> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000030> "WBls:0000030"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000030> "L2d-dauer lethargus Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000030> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000030> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000031>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000031> (L2d-dauer molt Ce)
@@ -1198,6 +1221,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000031> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000031> "WBls:0000031"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000031> "L2d-dauer molt Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000031> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000031> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000023>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000032> (dauer larva Ce)
@@ -1207,6 +1231,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000032> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000032> "WBls:0000032"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000032> "dauer larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000032> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000032> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000023>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000032> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000027>))
 
@@ -1217,6 +1242,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000033> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000033> "WBls:0000033"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000033> "postdauer-L4 lethargus Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000033> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000033> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000034>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000034> (postdauer-L4 molt Ce)
@@ -1226,6 +1252,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000034> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000034> "WBls:0000034"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000034> "postdauer-L4 molt Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000034> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000034> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000052>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000035> (L3 larva Ce)
@@ -1247,6 +1274,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000036> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000036> "WBls:0000036"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000036> "L3-L4 lethargus Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000036> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000036> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000037>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000037> (L3-L4 molt Ce)
@@ -1256,6 +1284,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000037> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000037> "WBls:0000037"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000037> "L3-L4 molt Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000037> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000037> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000023>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000037> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000035>))
 
@@ -1279,6 +1308,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000039> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000039> "WBls:0000039"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000039> "L4-adult lethargus Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000039> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000039> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000040>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000040> (L4-adult molt Ce)
@@ -1288,6 +1318,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000040> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000040> "WBls:0000040"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000040> "L4-adult molt Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000040> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000023>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000041> (adult Ce)
@@ -1310,6 +1341,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000042> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000042> "WBls:0000042"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000042> "L1-L2 ecdysis Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000042> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000042> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000026>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000042> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000025>))
 
@@ -1320,6 +1352,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000043> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000043> "WBls:0000043"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000043> "L1-L2d molt Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000043> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000043> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000023>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000044> (L1-L2d lethargus Ce)
@@ -1329,6 +1362,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000044> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000044> "WBls:0000044"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000044> "L1-L2d lethargus Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000044> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000044> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000043>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000045> (L1-L2d ecdysis Ce)
@@ -1338,6 +1372,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000045> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000045> "WBls:0000045"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000045> "L1-L2d ecdysis Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000045> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000045> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000043>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000046> (L2d larva Ce)
@@ -1347,6 +1382,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000046> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000046> "WBls:0000046"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000046> "L2d larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000046> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000046> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000023>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000047> (L2-L3 ecdysis Ce)
@@ -1356,6 +1392,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000047> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000047> "WBls:0000047"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000047> "L2-L3 ecdysis Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000047> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000047> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000029>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000047> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000028>))
 
@@ -1366,6 +1403,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000048> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000048> "WBls:0000048"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000048> "L2d-dauer ecdysis Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000048> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000048> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000031>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000049> (L3-L4 ecdysis Ce)
@@ -1375,15 +1413,17 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000049> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000049> "WBls:0000049"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000049> "L3-L4 ecdysis Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000049> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000037>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000036>))
 
-# Class: <http://purl.obolibrary.org/obo/WBls_0000050> (L4-adult ecdysis)
+# Class: <http://purl.obolibrary.org/obo/WBls_0000050> (L4-adult ecdysis Ce)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:wjc"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBls_0000050> "The stage during L4-adult molt, after the brief lethargus period, when an animal shed off old cuticle."^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000050> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000050> "WBls:0000050"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000050> "L4-adult ecdysis"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000050> "L4-adult ecdysis Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000050> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000040>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000039>))
 
@@ -1394,6 +1434,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000051> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000051> "WBls:0000051"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000051> "postdauer-L4 ecdysis Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000051> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000034>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000052> (post dauer stage Ce)
@@ -1403,6 +1444,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000052> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000052> "WBls:0000052"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000052> "post dauer stage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000052> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000052> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000023>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000053> (L2d-L3 molt Ce)
@@ -1412,6 +1454,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000053> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000053> "WBls:0000053"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000053> "L2d-L3 molt Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000053> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000053> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000046>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000054> (L2d-L3 lethargus Ce)
@@ -1421,6 +1464,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000054> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000054> "WBls:0000054"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000054> "L2d-L3 lethargus Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000054> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000054> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000053>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000055> (L2d-L3 ecdysis Ce)
@@ -1430,6 +1474,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000055> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000055> "WBls:0000055"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000055> "L2d-L3 ecdysis Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000055> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000055> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000053>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000056> (adult male Ce)
@@ -1457,6 +1502,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000058> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000058> "WBls:0000058"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000058> "pre-reproductive stage adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000058> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000058> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000059> (parasitic nematode stage)
@@ -1476,6 +1522,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000060> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000060> "WBls:0000060"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000060> "reproductive stage adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000060> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000060> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000061> (oocyte-laying stage adult hermaphrodite Ce)
@@ -1485,6 +1532,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000061> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000061> "WBls:0000061"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000061> "oocyte-laying stage adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000061> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000061> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000062> (post-reproductive stage adult hermaphrodite Ce)
@@ -1494,6 +1542,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000062> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000062> "WBls:0000062"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000062> "post-reproductive stage adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000062> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000062> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000063> (newly molted young adult hermaphrodite Ce)
@@ -1503,6 +1552,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000063> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000063> "WBls:0000063"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000063> "newly molted young adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000063> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000063> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000064> (1-day post-L4 adult hermaphrodite Ce)
@@ -1512,6 +1562,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000064> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000064> "WBls:0000064"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000064> "1-day post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000064> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000064> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000065> (2-days post-L4 adult hermaphrodite Ce)
@@ -1521,6 +1572,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000065> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000065> "WBls:0000065"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000065> "2-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000065> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000065> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000065> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000064>))
 
@@ -1531,6 +1583,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000066> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000066> "WBls:0000066"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000066> "3-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000066> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000066> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000066> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000065>))
 
@@ -1541,6 +1594,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000067> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000067> "WBls:0000067"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000067> "4-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000067> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000067> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000067> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000066>))
 
@@ -1551,6 +1605,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000068> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000068> "WBls:0000068"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000068> "5-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000068> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000068> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000068> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000067>))
 
@@ -1561,6 +1616,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000069> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000069> "WBls:0000069"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000069> "4-7 days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000069> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000069> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000069> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000068>))
 
@@ -1571,6 +1627,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000070> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000070> "WBls:0000070"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000070> "7-10 days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000070> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000069>))
 
@@ -1581,6 +1638,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000071> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000071> "WBls:0000071"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000071> "8-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000071> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000071> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000071> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000008>))
 
@@ -1591,6 +1649,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000072> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000072> "WBls:0000072"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000072> "12-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000072> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000072> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000072> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000071>))
 
@@ -1603,14 +1662,15 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000073> "L4 larva male Ce"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000073> <http://purl.obolibrary.org/obo/WBls_0000038>)
 
-# Class: <http://purl.obolibrary.org/obo/WBls_0000074> (11-15 days post-L4 adult hermaphrodite)
+# Class: <http://purl.obolibrary.org/obo/WBls_0000074> (11-15 days post-L4 adult hermaphrodite Ce)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "WB:dr"^^xsd:string) <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/WBls_0000074> "At 20 Centigrade: 11-15 days after L4-adult molt. 14-18 days after first cleavage."^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.obolibrary.org/obo/WBls_0000074> "danielaraciti"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.obolibrary.org/obo/WBls_0000074> "2012-05-22T14:35:04Z"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000074> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000074> "WBls:0000074"^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000074> "11-15 days post-L4 adult hermaphrodite"^^xsd:string)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000074> "11-15 days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000074> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000074> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000074> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000674>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000074> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000070>))
@@ -1736,6 +1796,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespac
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000084> "WBls:0000084"^^xsd:string)
 AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBls_0000084> "Levin M, Hashimshony T, Wagner F, Yanai I. Developmental milestones punctuate gene expression in the Caenorhabditis embryo. Dev Cell. 2012 May 15;22(5):1101-8. Epub 2012 May 3. PubMed PMID: 22560298. Supplementary table 1."^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000084> "14-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000084> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000084> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000084> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000072>))
 
@@ -1749,6 +1810,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespac
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000085> "WBls:0000085"^^xsd:string)
 AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBls_0000085> "Levin M, Hashimshony T, Wagner F, Yanai I. Developmental milestones punctuate gene expression in the Caenorhabditis embryo. Dev Cell. 2012 May 15;22(5):1101-8. Epub 2012 May 3. PubMed PMID: 22560298. Supplementary table 1."^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000085> "24-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000085> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000085> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000085> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000084>))
 
@@ -1762,6 +1824,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespac
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000086> "WBls:0000086"^^xsd:string)
 AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBls_0000086> "Levin M, Hashimshony T, Wagner F, Yanai I. Developmental milestones punctuate gene expression in the Caenorhabditis embryo. Dev Cell. 2012 May 15;22(5):1101-8. Epub 2012 May 3. PubMed PMID: 22560298. Supplementary table 1."^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000086> "44-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000086> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000086> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000086> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000009>))
 
@@ -1775,6 +1838,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespac
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000087> "WBls:0000087"^^xsd:string)
 AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBls_0000087> "Levin M, Hashimshony T, Wagner F, Yanai I. Developmental milestones punctuate gene expression in the Caenorhabditis embryo. Dev Cell. 2012 May 15;22(5):1101-8. Epub 2012 May 3. PubMed PMID: 22560298. Supplementary table 1."^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000087> "68-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000087> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000087> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000087> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000011>))
 
@@ -1788,6 +1852,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespac
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000088> "WBls:0000088"^^xsd:string)
 AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/WBls_0000088> "Levin M, Hashimshony T, Wagner F, Yanai I. Developmental milestones punctuate gene expression in the Caenorhabditis embryo. Dev Cell. 2012 May 15;22(5):1101-8. Epub 2012 May 3. PubMed PMID: 22560298. Supplementary table 1."^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000088> "86-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000088> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000088> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000088> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000087>))
 
@@ -1800,6 +1865,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000089> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000089> "WBls:0000089"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000089> "190-cells embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000089> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000089> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000089> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000090>))
 
@@ -1812,6 +1878,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000090> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000090> "WBls:0000090"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000090> "96-cell embryo Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000090> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000090> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000090> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000012>))
 
@@ -1863,6 +1930,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000094> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000094> "WBls:0000094"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000094> "Brugia early embryo"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000094> <http://purl.obolibrary.org/obo/WBls_0000091>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000094> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000092>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000095> (Brugia middle embryo)
@@ -1875,6 +1943,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000095> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000095> "WBls:0000095"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000095> "Brugia middle embryo"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000095> <http://purl.obolibrary.org/obo/WBls_0000091>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000095> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000092>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000095> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000094>))
 
@@ -1888,6 +1957,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000096> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000096> "WBls:0000096"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000096> "Brugia late embryo"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000096> <http://purl.obolibrary.org/obo/WBls_0000091>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000096> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000092>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000096> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000095>))
 
@@ -1932,6 +2002,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespac
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/WBls_0000099> "piL3"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000099> "WBls:0000099"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000099> "Brugia post-infection L3"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000099> <http://purl.obolibrary.org/obo/WBls_0000091>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000099> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000081>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000100> (Brugia young adult)
@@ -1944,6 +2015,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000100> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000100> "WBls:0000100"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000100> "Brugia young adult"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000100> <http://purl.obolibrary.org/obo/WBls_0000091>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000100> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000093>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000100> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000082>))
 
@@ -2076,6 +2148,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000111> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000111> "WBls:0000111"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000111> "16-18 days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000111> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000111> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000111> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000675>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000111> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000074>))
@@ -2089,6 +2162,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000112> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000112> "WBls:0000112"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000112> "1 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000112> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000112> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000113> (2 min post first-cleavage Ce)
@@ -2100,6 +2174,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000113> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000113> "WBls:0000113"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000113> "2 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000113> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000113> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000113> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000112>))
 
@@ -2112,6 +2187,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000114> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000114> "WBls:0000114"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000114> "3 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000114> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000114> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000114> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000113>))
 
@@ -2124,6 +2200,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000115> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000115> "WBls:0000115"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000115> "4 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000115> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000115> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000115> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000114>))
 
@@ -2136,6 +2213,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000116> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000116> "WBls:0000116"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000116> "5 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000116> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000116> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000116> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000115>))
 
@@ -2148,6 +2226,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000117> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000117> "WBls:0000117"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000117> "6 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000117> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000117> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000117> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000116>))
 
@@ -2160,6 +2239,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000118> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000118> "WBls:0000118"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000118> "7 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000118> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000118> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000118> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000117>))
 
@@ -2172,6 +2252,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000119> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000119> "WBls:0000119"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000119> "8 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000119> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000119> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000119> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000118>))
 
@@ -2184,6 +2265,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000120> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000120> "WBls:0000120"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000120> "9 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000120> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000120> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000120> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000119>))
 
@@ -2196,6 +2278,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000121> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000121> "WBls:0000121"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000121> "10 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000121> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000121> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000121> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000120>))
 
@@ -2208,6 +2291,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000122> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000122> "WBls:0000122"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000122> "11 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000122> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000122> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000122> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000121>))
 
@@ -2220,6 +2304,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000123> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000123> "WBls:0000123"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000123> "12 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000123> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000123> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000123> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000122>))
 
@@ -2232,6 +2317,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000124> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000124> "WBls:0000124"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000124> "13 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000124> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000124> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000124> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000123>))
 
@@ -2244,6 +2330,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000125> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000125> "WBls:0000125"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000125> "14 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000125> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000125> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000125> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000124>))
 
@@ -2256,6 +2343,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000126> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000126> "WBls:0000126"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000126> "15 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000126> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000126> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000126> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000125>))
 
@@ -2268,6 +2356,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000127> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000127> "WBls:0000127"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000127> "16 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000127> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000127> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000127> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000126>))
 
@@ -2280,6 +2369,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000128> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000128> "WBls:0000128"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000128> "17 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000128> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000128> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000128> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000127>))
 
@@ -2292,6 +2382,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000129> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000129> "WBls:0000129"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000129> "18 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000129> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000129> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000129> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000128>))
 
@@ -2304,6 +2395,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000130> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000130> "WBls:0000130"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000130> "19 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000130> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000130> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000130> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000129>))
 
@@ -2316,6 +2408,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000131> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000131> "WBls:0000131"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000131> "20 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000131> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000131> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000131> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000130>))
 
@@ -2328,6 +2421,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000132> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000132> "WBls:0000132"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000132> "21 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000132> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000132> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000132> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000131>))
 
@@ -2340,6 +2434,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000133> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000133> "WBls:0000133"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000133> "22 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000133> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000133> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000133> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000132>))
 
@@ -2352,6 +2447,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000134> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000134> "WBls:0000134"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000134> "23 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000134> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000134> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000134> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000133>))
 
@@ -2364,6 +2460,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000135> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000135> "WBls:0000135"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000135> "24 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000135> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000135> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000135> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000134>))
 
@@ -2376,6 +2473,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000136> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000136> "WBls:0000136"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000136> "25 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000136> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000136> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000136> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000135>))
 
@@ -2388,6 +2486,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000137> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000137> "WBls:0000137"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000137> "26 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000137> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000137> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000137> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000136>))
 
@@ -2400,6 +2499,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000138> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000138> "WBls:0000138"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000138> "27 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000138> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000138> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000138> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000137>))
 
@@ -2412,6 +2512,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000139> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000139> "WBls:0000139"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000139> "28 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000139> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000139> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000139> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000138>))
 
@@ -2424,6 +2525,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000140> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000140> "WBls:0000140"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000140> "29 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000140> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000140> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000140> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000139>))
 
@@ -2436,6 +2538,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000141> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000141> "WBls:0000141"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000141> "30 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000141> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000141> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000141> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000140>))
 
@@ -2448,6 +2551,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000142> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000142> "WBls:0000142"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000142> "31 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000142> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000142> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000142> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000141>))
 
@@ -2460,6 +2564,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000143> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000143> "WBls:0000143"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000143> "32 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000143> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000143> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000143> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000142>))
 
@@ -2472,6 +2577,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000144> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000144> "WBls:0000144"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000144> "33 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000144> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000144> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000144> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000143>))
 
@@ -2484,6 +2590,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000145> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000145> "WBls:0000145"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000145> "34 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000145> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000145> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000145> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000144>))
 
@@ -2496,6 +2603,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000146> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000146> "WBls:0000146"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000146> "35 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000146> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000146> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000146> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000145>))
 
@@ -2508,6 +2616,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000147> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000147> "WBls:0000147"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000147> "36 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000147> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000147> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000147> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000146>))
 
@@ -2520,6 +2629,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000148> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000148> "WBls:0000148"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000148> "37 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000148> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000148> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000148> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000147>))
 
@@ -2532,6 +2642,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000149> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000149> "WBls:0000149"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000149> "38 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000149> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000149> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000149> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000148>))
 
@@ -2544,6 +2655,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000150> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000150> "WBls:0000150"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000150> "39 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000150> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000150> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000149>))
 
@@ -2556,6 +2668,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000151> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000151> "WBls:0000151"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000151> "40 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000151> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000151> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000151> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000150>))
 
@@ -2568,6 +2681,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000152> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000152> "WBls:0000152"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000152> "41 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000152> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000152> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000152> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000151>))
 
@@ -2580,6 +2694,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000153> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000153> "WBls:0000153"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000153> "42 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000153> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000153> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000153> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000152>))
 
@@ -2592,6 +2707,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000154> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000154> "WBls:0000154"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000154> "43 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000154> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000154> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000154> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000153>))
 
@@ -2604,6 +2720,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000155> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000155> "WBls:0000155"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000155> "44 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000155> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000155> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000155> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000154>))
 
@@ -2616,6 +2733,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000156> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000156> "WBls:0000156"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000156> "45 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000156> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000156> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000156> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000155>))
 
@@ -2628,6 +2746,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000157> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000157> "WBls:0000157"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000157> "46 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000157> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000157> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000157> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000156>))
 
@@ -2640,6 +2759,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000158> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000158> "WBls:0000158"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000158> "47 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000158> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000158> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000158> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000157>))
 
@@ -2652,6 +2772,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000159> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000159> "WBls:0000159"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000159> "48 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000159> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000159> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000159> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000158>))
 
@@ -2664,6 +2785,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000160> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000160> "WBls:0000160"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000160> "49 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000160> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000160> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000160> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000159>))
 
@@ -2676,6 +2798,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000161> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000161> "WBls:0000161"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000161> "50 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000161> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000161> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000161> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000160>))
 
@@ -2688,6 +2811,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000162> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000162> "WBls:0000162"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000162> "51 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000162> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000162> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000162> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000161>))
 
@@ -2700,6 +2824,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000163> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000163> "WBls:0000163"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000163> "52 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000163> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000163> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000163> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000162>))
 
@@ -2712,6 +2837,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000164> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000164> "WBls:0000164"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000164> "53 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000164> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000164> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000164> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000163>))
 
@@ -2724,6 +2850,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000165> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000165> "WBls:0000165"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000165> "54 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000165> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000164>))
 
@@ -2736,6 +2863,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000166> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000166> "WBls:0000166"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000166> "55 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000166> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000166> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000166> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000165>))
 
@@ -2748,6 +2876,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000167> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000167> "WBls:0000167"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000167> "56 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000167> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000167> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000167> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000166>))
 
@@ -2760,6 +2889,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000168> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000168> "WBls:0000168"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000168> "57 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000168> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000168> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000168> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000167>))
 
@@ -2772,6 +2902,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000169> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000169> "WBls:0000169"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000169> "58 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000169> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000169> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000169> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000168>))
 
@@ -2784,6 +2915,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000170> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000170> "WBls:0000170"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000170> "59 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000170> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000170> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000170> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000169>))
 
@@ -2796,6 +2928,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000171> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000171> "WBls:0000171"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000171> "60 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000171> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000171> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000171> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000170>))
 
@@ -2808,6 +2941,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000172> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000172> "WBls:0000172"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000172> "61 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000172> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000172> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000172> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000171>))
 
@@ -2820,6 +2954,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000173> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000173> "WBls:0000173"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000173> "62 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000173> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000173> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000173> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000172>))
 
@@ -2832,6 +2967,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000174> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000174> "WBls:0000174"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000174> "63 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000174> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000174> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000174> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000173>))
 
@@ -2844,6 +2980,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000175> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000175> "WBls:0000175"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000175> "64 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000175> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000175> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000175> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000174>))
 
@@ -2856,6 +2993,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000176> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000176> "WBls:0000176"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000176> "65 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000176> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000176> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000176> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000175>))
 
@@ -2868,6 +3006,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000177> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000177> "WBls:0000177"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000177> "66 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000177> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000177> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000177> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000176>))
 
@@ -2880,6 +3019,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000178> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000178> "WBls:0000178"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000178> "67 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000178> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000178> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000177>))
 
@@ -2892,6 +3032,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000179> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000179> "WBls:0000179"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000179> "68 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000179> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000179> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000179> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000178>))
 
@@ -2904,6 +3045,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000180> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000180> "WBls:0000180"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000180> "69 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000180> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000180> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000180> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000179>))
 
@@ -2916,6 +3058,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000181> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000181> "WBls:0000181"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000181> "70 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000181> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000181> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000181> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000180>))
 
@@ -2928,6 +3071,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000182> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000182> "WBls:0000182"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000182> "71 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000182> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000182> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000182> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000181>))
 
@@ -2940,6 +3084,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000183> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000183> "WBls:0000183"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000183> "72 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000183> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000183> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000183> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000182>))
 
@@ -2952,6 +3097,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000184> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000184> "WBls:0000184"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000184> "73 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000184> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000184> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000184> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000183>))
 
@@ -2964,6 +3110,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000185> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000185> "WBls:0000185"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000185> "74 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000185> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000185> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000185> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000184>))
 
@@ -2976,6 +3123,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000186> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000186> "WBls:0000186"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000186> "75 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000186> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000186> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000186> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000185>))
 
@@ -2988,6 +3136,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000187> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000187> "WBls:0000187"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000187> "76 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000187> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000187> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000187> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000186>))
 
@@ -3000,6 +3149,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000188> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000188> "WBls:0000188"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000188> "77 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000188> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000188> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000188> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000187>))
 
@@ -3012,6 +3162,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000189> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000189> "WBls:0000189"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000189> "78 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000189> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000189> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000189> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000188>))
 
@@ -3024,6 +3175,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000190> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000190> "WBls:0000190"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000190> "79 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000190> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000190> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000190> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000189>))
 
@@ -3036,6 +3188,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000191> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000191> "WBls:0000191"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000191> "80 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000191> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000191> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000191> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000190>))
 
@@ -3048,6 +3201,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000192> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000192> "WBls:0000192"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000192> "81 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000192> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000191>))
 
@@ -3060,6 +3214,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000193> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000193> "WBls:0000193"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000193> "82 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000193> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000193> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000193> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000192>))
 
@@ -3072,6 +3227,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000194> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000194> "WBls:0000194"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000194> "83 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000194> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000194> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000194> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000193>))
 
@@ -3084,6 +3240,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000195> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000195> "WBls:0000195"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000195> "84 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000195> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000195> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000195> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000194>))
 
@@ -3096,6 +3253,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000196> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000196> "WBls:0000196"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000196> "85 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000196> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000196> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000196> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000195>))
 
@@ -3108,6 +3266,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000197> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000197> "WBls:0000197"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000197> "86 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000197> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000196>))
 
@@ -3120,6 +3279,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000198> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000198> "WBls:0000198"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000198> "87 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000198> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000198> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000198> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000197>))
 
@@ -3132,6 +3292,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000199> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000199> "WBls:0000199"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000199> "88 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000199> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000199> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000199> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000198>))
 
@@ -3144,6 +3305,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000200> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000200> "WBls:0000200"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000200> "89 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000200> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000200> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000200> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000199>))
 
@@ -3156,6 +3318,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000201> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000201> "WBls:0000201"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000201> "90 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000201> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000201> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000201> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000200>))
 
@@ -3168,6 +3331,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000202> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000202> "WBls:0000202"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000202> "91 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000202> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000202> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000202> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000201>))
 
@@ -3180,6 +3344,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000203> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000203> "WBls:0000203"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000203> "92 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000203> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000203> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000203> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000202>))
 
@@ -3192,6 +3357,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000204> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000204> "WBls:0000204"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000204> "93 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000204> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000204> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000204> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000203>))
 
@@ -3204,6 +3370,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000205> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000205> "WBls:0000205"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000205> "94 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000205> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000205> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000205> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000204>))
 
@@ -3216,6 +3383,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000206> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000206> "WBls:0000206"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000206> "95 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000206> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000206> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000206> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000205>))
 
@@ -3228,6 +3396,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000207> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000207> "WBls:0000207"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000207> "96 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000207> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000207> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000207> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000206>))
 
@@ -3240,6 +3409,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000208> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000208> "WBls:0000208"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000208> "97 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000208> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000208> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000208> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000207>))
 
@@ -3252,6 +3422,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000209> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000209> "WBls:0000209"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000209> "98 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000209> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000209> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000209> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000208>))
 
@@ -3264,6 +3435,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000210> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000210> "WBls:0000210"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000210> "99 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000210> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000210> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000210> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000209>))
 
@@ -3276,6 +3448,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000211> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000211> "WBls:0000211"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000211> "100 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000211> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000211> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000005>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000211> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000210>))
 
@@ -3288,6 +3461,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000212> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000212> "WBls:0000212"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000212> "101 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000212> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000212> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000212> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000211>))
 
@@ -3300,6 +3474,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000213> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000213> "WBls:0000213"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000213> "102 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000213> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000213> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000213> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000212>))
 
@@ -3312,6 +3487,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000214> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000214> "WBls:0000214"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000214> "103 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000214> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000214> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000214> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000213>))
 
@@ -3324,6 +3500,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000215> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000215> "WBls:0000215"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000215> "104 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000215> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000215> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000215> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000214>))
 
@@ -3336,6 +3513,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000216> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000216> "WBls:0000216"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000216> "105 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000216> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000216> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000216> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000215>))
 
@@ -3348,6 +3526,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000217> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000217> "WBls:0000217"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000217> "106 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000217> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000217> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000217> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000216>))
 
@@ -3360,6 +3539,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000218> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000218> "WBls:0000218"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000218> "107 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000218> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000218> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000218> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000217>))
 
@@ -3372,6 +3552,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000219> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000219> "WBls:0000219"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000219> "108 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000219> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000219> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000219> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000218>))
 
@@ -3384,6 +3565,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000220> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000220> "WBls:0000220"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000220> "109 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000220> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000220> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000220> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000219>))
 
@@ -3396,6 +3578,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000221> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000221> "WBls:0000221"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000221> "110 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000221> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000221> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000221> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000220>))
 
@@ -3408,6 +3591,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000222> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000222> "WBls:0000222"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000222> "111 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000222> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000222> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000222> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000221>))
 
@@ -3420,6 +3604,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000223> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000223> "WBls:0000223"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000223> "112 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000223> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000223> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000223> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000222>))
 
@@ -3432,6 +3617,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000224> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000224> "WBls:0000224"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000224> "113 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000224> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000224> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000224> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000223>))
 
@@ -3444,6 +3630,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000225> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000225> "WBls:0000225"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000225> "114 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000225> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000225> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000225> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000224>))
 
@@ -3456,6 +3643,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000226> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000226> "WBls:0000226"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000226> "115 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000226> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000226> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000226> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000225>))
 
@@ -3468,6 +3656,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000227> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000227> "WBls:0000227"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000227> "116 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000227> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000227> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000226>))
 
@@ -3480,6 +3669,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000228> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000228> "WBls:0000228"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000228> "117 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000228> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000228> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000227>))
 
@@ -3492,6 +3682,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000229> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000229> "WBls:0000229"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000229> "118 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000229> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000229> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000229> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000228>))
 
@@ -3504,6 +3695,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000230> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000230> "WBls:0000230"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000230> "119 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000230> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000230> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000230> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000229>))
 
@@ -3516,6 +3708,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000231> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000231> "WBls:0000231"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000231> "120 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000231> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000231> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000231> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000230>))
 
@@ -3528,6 +3721,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000232> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000232> "WBls:0000232"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000232> "121 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000232> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000232> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000232> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000231>))
 
@@ -3540,6 +3734,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000233> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000233> "WBls:0000233"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000233> "122 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000233> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000233> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000233> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000232>))
 
@@ -3552,6 +3747,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000234> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000234> "WBls:0000234"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000234> "123 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000234> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000234> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000234> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000233>))
 
@@ -3564,6 +3760,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000235> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000235> "WBls:0000235"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000235> "124 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000235> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000235> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000235> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000234>))
 
@@ -3576,6 +3773,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000236> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000236> "WBls:0000236"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000236> "125 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000236> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000236> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000235>))
 
@@ -3588,6 +3786,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000237> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000237> "WBls:0000237"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000237> "126 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000237> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000237> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000237> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000236>))
 
@@ -3600,6 +3799,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000238> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000238> "WBls:0000238"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000238> "127 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000238> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000238> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000238> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000237>))
 
@@ -3612,6 +3812,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000239> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000239> "WBls:0000239"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000239> "128 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000239> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000239> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000239> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000238>))
 
@@ -3624,6 +3825,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000240> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000240> "WBls:0000240"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000240> "129 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000240> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000240> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000240> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000239>))
 
@@ -3636,6 +3838,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000241> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000241> "WBls:0000241"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000241> "130 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000241> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000241> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000241> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000240>))
 
@@ -3648,6 +3851,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000242> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000242> "WBls:0000242"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000242> "131 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000242> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000242> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000242> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000241>))
 
@@ -3660,6 +3864,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000243> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000243> "WBls:0000243"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000243> "132 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000243> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000243> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000243> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000242>))
 
@@ -3672,6 +3877,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000244> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000244> "WBls:0000244"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000244> "133 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000244> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000244> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000244> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000243>))
 
@@ -3684,6 +3890,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000245> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000245> "WBls:0000245"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000245> "134 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000245> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000245> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000245> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000244>))
 
@@ -3696,6 +3903,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000246> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000246> "WBls:0000246"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000246> "135 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000246> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000246> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000246> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000245>))
 
@@ -3708,6 +3916,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000247> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000247> "WBls:0000247"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000247> "136 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000247> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000247> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000247> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000246>))
 
@@ -3720,6 +3929,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000248> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000248> "WBls:0000248"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000248> "137 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000248> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000248> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000248> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000247>))
 
@@ -3732,6 +3942,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000249> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000249> "WBls:0000249"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000249> "138 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000249> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000249> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000249> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000248>))
 
@@ -3744,6 +3955,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000250> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000250> "WBls:0000250"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000250> "139 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000250> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000250> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000250> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000249>))
 
@@ -3756,6 +3968,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000251> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000251> "WBls:0000251"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000251> "140 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000251> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000251> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000251> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000250>))
 
@@ -3768,6 +3981,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000252> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000252> "WBls:0000252"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000252> "141 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000252> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000251>))
 
@@ -3780,6 +3994,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000253> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000253> "WBls:0000253"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000253> "142 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000253> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000253> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000253> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000252>))
 
@@ -3792,6 +4007,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000254> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000254> "WBls:0000254"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000254> "143 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000254> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000254> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000254> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000253>))
 
@@ -3804,6 +4020,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000255> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000255> "WBls:0000255"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000255> "144 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000255> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000255> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000255> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000254>))
 
@@ -3816,6 +4033,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000256> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000256> "WBls:0000256"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000256> "145 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000256> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000256> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000256> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000255>))
 
@@ -3828,6 +4046,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000257> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000257> "WBls:0000257"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000257> "146 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000257> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000257> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000257> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000256>))
 
@@ -3840,6 +4059,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000258> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000258> "WBls:0000258"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000258> "147 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000258> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000258> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000258> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000257>))
 
@@ -3852,6 +4072,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000259> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000259> "WBls:0000259"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000259> "148 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000259> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000259> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000259> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000258>))
 
@@ -3864,6 +4085,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000260> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000260> "WBls:0000260"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000260> "149 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000260> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000260> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000260> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000259>))
 
@@ -3876,6 +4098,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000261> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000261> "WBls:0000261"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000261> "150 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000261> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000261> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000261> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000260>))
 
@@ -3888,6 +4111,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000262> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000262> "WBls:0000262"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000262> "151 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000262> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000262> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000262> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000261>))
 
@@ -3900,6 +4124,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000263> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000263> "WBls:0000263"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000263> "152 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000263> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000263> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000263> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000262>))
 
@@ -3912,6 +4137,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000264> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000264> "WBls:0000264"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000264> "153 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000264> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000264> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000264> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000263>))
 
@@ -3924,6 +4150,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000265> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000265> "WBls:0000265"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000265> "154 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000265> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000265> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000265> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000264>))
 
@@ -3936,6 +4163,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000266> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000266> "WBls:0000266"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000266> "155 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000266> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000266> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000266> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000265>))
 
@@ -3948,6 +4176,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000267> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000267> "WBls:0000267"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000267> "156 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000267> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000267> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000267> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000266>))
 
@@ -3960,6 +4189,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000268> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000268> "WBls:0000268"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000268> "157 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000268> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000268> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000268> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000267>))
 
@@ -3972,6 +4202,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000269> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000269> "WBls:0000269"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000269> "158 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000269> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000269> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000269> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000268>))
 
@@ -3984,6 +4215,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000270> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000270> "WBls:0000270"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000270> "159 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000270> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000270> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000270> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000269>))
 
@@ -3996,6 +4228,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000271> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000271> "WBls:0000271"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000271> "160 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000271> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000271> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000271> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000270>))
 
@@ -4008,6 +4241,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000272> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000272> "WBls:0000272"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000272> "161 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000272> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000272> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000272> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000271>))
 
@@ -4020,6 +4254,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000273> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000273> "WBls:0000273"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000273> "162 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000273> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000273> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000273> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000272>))
 
@@ -4032,6 +4267,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000274> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000274> "WBls:0000274"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000274> "163 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000274> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000274> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000274> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000273>))
 
@@ -4044,6 +4280,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000275> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000275> "WBls:0000275"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000275> "164 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000275> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000275> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000275> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000274>))
 
@@ -4056,6 +4293,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000276> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000276> "WBls:0000276"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000276> "165 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000276> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000276> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000276> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000275>))
 
@@ -4068,6 +4306,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000277> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000277> "WBls:0000277"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000277> "166 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000277> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000277> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000277> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000276>))
 
@@ -4080,6 +4319,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000278> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000278> "WBls:0000278"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000278> "167 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000278> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000278> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000278> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000277>))
 
@@ -4092,6 +4332,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000279> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000279> "WBls:0000279"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000279> "168 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000279> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000279> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000279> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000278>))
 
@@ -4104,6 +4345,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000280> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000280> "WBls:0000280"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000280> "169 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000280> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000280> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000280> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000279>))
 
@@ -4116,6 +4358,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000281> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000281> "WBls:0000281"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000281> "170 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000281> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000281> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000281> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000280>))
 
@@ -4128,6 +4371,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000282> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000282> "WBls:0000282"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000282> "171 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000282> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000282> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000282> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000281>))
 
@@ -4140,6 +4384,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000283> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000283> "WBls:0000283"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000283> "172 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000283> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000283> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000283> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000282>))
 
@@ -4152,6 +4397,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000284> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000284> "WBls:0000284"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000284> "173 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000284> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000284> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000284> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000283>))
 
@@ -4164,6 +4410,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000285> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000285> "WBls:0000285"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000285> "174 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000285> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000285> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000285> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000284>))
 
@@ -4176,6 +4423,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000286> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000286> "WBls:0000286"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000286> "175 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000286> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000286> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000286> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000285>))
 
@@ -4188,6 +4436,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000287> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000287> "WBls:0000287"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000287> "176 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000287> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000287> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000287> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000286>))
 
@@ -4200,6 +4449,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000288> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000288> "WBls:0000288"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000288> "177 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000288> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000288> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000288> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000287>))
 
@@ -4212,6 +4462,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000289> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000289> "WBls:0000289"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000289> "178 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000289> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000289> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000289> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000288>))
 
@@ -4224,6 +4475,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000290> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000290> "WBls:0000290"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000290> "179 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000290> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000290> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000290> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000289>))
 
@@ -4236,6 +4488,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000291> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000291> "WBls:0000291"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000291> "180 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000291> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000291> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000291> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000290>))
 
@@ -4248,6 +4501,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000292> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000292> "WBls:0000292"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000292> "181 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000292> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000292> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000292> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000291>))
 
@@ -4260,6 +4514,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000293> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000293> "WBls:0000293"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000293> "182 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000293> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000293> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000293> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000292>))
 
@@ -4272,6 +4527,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000294> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000294> "WBls:0000294"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000294> "183 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000294> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000294> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000294> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000293>))
 
@@ -4284,6 +4540,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000295> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000295> "WBls:0000295"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000295> "184 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000295> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000295> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000295> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000294>))
 
@@ -4296,6 +4553,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000296> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000296> "WBls:0000296"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000296> "185 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000296> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000296> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000296> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000295>))
 
@@ -4308,6 +4566,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000297> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000297> "WBls:0000297"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000297> "186 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000297> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000297> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000296>))
 
@@ -4320,6 +4579,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000298> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000298> "WBls:0000298"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000298> "187 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000298> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000298> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000298> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000297>))
 
@@ -4332,6 +4592,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000299> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000299> "WBls:0000299"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000299> "188 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000299> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000299> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000299> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000298>))
 
@@ -4344,6 +4605,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000300> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000300> "WBls:0000300"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000300> "189 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000300> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000300> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000300> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000299>))
 
@@ -4356,6 +4618,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000301> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000301> "WBls:0000301"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000301> "190 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000301> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000301> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000301> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000300>))
 
@@ -4368,6 +4631,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000302> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000302> "WBls:0000302"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000302> "191 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000302> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000302> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000302> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000301>))
 
@@ -4380,6 +4644,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000303> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000303> "WBls:0000303"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000303> "192 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000303> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000303> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000303> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000302>))
 
@@ -4392,6 +4657,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000304> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000304> "WBls:0000304"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000304> "193 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000304> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000304> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000303>))
 
@@ -4404,6 +4670,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000305> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000305> "WBls:0000305"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000305> "194 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000305> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000305> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000305> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000304>))
 
@@ -4416,6 +4683,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000306> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000306> "WBls:0000306"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000306> "195 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000306> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000306> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000306> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000305>))
 
@@ -4428,6 +4696,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000307> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000307> "WBls:0000307"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000307> "196 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000307> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000307> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000307> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000306>))
 
@@ -4440,6 +4709,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000308> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000308> "WBls:0000308"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000308> "197 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000308> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000308> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000308> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000307>))
 
@@ -4452,6 +4722,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000309> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000309> "WBls:0000309"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000309> "198 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000309> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000309> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000309> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000308>))
 
@@ -4464,6 +4735,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000310> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000310> "WBls:0000310"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000310> "199 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000310> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000310> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000310> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000309>))
 
@@ -4476,6 +4748,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000311> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000311> "WBls:0000311"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000311> "200 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000311> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000311> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000311> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000310>))
 
@@ -4488,6 +4761,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000312> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000312> "WBls:0000312"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000312> "201 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000312> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000312> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000312> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000311>))
 
@@ -4500,6 +4774,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000313> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000313> "WBls:0000313"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000313> "202 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000313> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000313> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000313> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000312>))
 
@@ -4512,6 +4787,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000314> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000314> "WBls:0000314"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000314> "203 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000314> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000314> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000314> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000313>))
 
@@ -4524,6 +4800,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000315> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000315> "WBls:0000315"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000315> "204 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000315> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000315> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000315> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000314>))
 
@@ -4536,6 +4813,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000316> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000316> "WBls:0000316"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000316> "205 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000316> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000316> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000316> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000315>))
 
@@ -4548,6 +4826,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000317> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000317> "WBls:0000317"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000317> "206 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000317> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000317> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000317> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000316>))
 
@@ -4560,6 +4839,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000318> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000318> "WBls:0000318"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000318> "207 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000318> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000318> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000318> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000317>))
 
@@ -4572,6 +4852,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000319> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000319> "WBls:0000319"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000319> "208 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000319> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000319> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000319> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000318>))
 
@@ -4584,6 +4865,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000320> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000320> "WBls:0000320"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000320> "209 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000320> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000320> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000320> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000319>))
 
@@ -4596,6 +4878,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000321> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000321> "WBls:0000321"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000321> "210 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000321> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000321> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000321> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000320>))
 
@@ -4608,6 +4891,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000322> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000322> "WBls:0000322"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000322> "211 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000322> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000322> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000322> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000321>))
 
@@ -4620,6 +4904,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000323> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000323> "WBls:0000323"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000323> "212 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000323> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000323> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000323> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000322>))
 
@@ -4632,6 +4917,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000324> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000324> "WBls:0000324"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000324> "213 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000324> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000324> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000324> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000323>))
 
@@ -4644,6 +4930,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000325> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000325> "WBls:0000325"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000325> "214 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000325> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000325> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000325> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000324>))
 
@@ -4656,6 +4943,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000326> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000326> "WBls:0000326"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000326> "215 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000326> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000326> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000326> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000325>))
 
@@ -4668,6 +4956,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000327> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000327> "WBls:0000327"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000327> "216 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000327> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000327> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000327> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000326>))
 
@@ -4680,6 +4969,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000328> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000328> "WBls:0000328"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000328> "217 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000328> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000328> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000328> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000327>))
 
@@ -4692,6 +4982,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000329> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000329> "WBls:0000329"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000329> "218 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000329> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000329> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000329> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000328>))
 
@@ -4704,6 +4995,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000330> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000330> "WBls:0000330"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000330> "219 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000330> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000330> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000330> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000329>))
 
@@ -4716,6 +5008,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000331> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000331> "WBls:0000331"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000331> "220 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000331> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000331> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000331> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000330>))
 
@@ -4728,6 +5021,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000332> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000332> "WBls:0000332"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000332> "221 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000332> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000332> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000332> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000331>))
 
@@ -4740,6 +5034,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000333> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000333> "WBls:0000333"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000333> "222 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000333> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000333> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000333> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000332>))
 
@@ -4752,6 +5047,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000334> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000334> "WBls:0000334"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000334> "223 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000334> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000334> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000334> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000333>))
 
@@ -4764,6 +5060,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000335> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000335> "WBls:0000335"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000335> "224 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000335> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000335> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000335> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000334>))
 
@@ -4776,6 +5073,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000336> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000336> "WBls:0000336"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000336> "225 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000336> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000336> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000336> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000335>))
 
@@ -4788,6 +5086,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000337> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000337> "WBls:0000337"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000337> "226 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000337> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000337> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000337> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000336>))
 
@@ -4800,6 +5099,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000338> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000338> "WBls:0000338"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000338> "227 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000338> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000338> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000338> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000337>))
 
@@ -4812,6 +5112,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000339> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000339> "WBls:0000339"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000339> "228 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000339> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000339> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000339> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000338>))
 
@@ -4824,6 +5125,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000340> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000340> "WBls:0000340"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000340> "229 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000340> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000340> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000340> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000339>))
 
@@ -4836,6 +5138,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000341> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000341> "WBls:0000341"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000341> "230 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000341> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000341> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000341> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000340>))
 
@@ -4848,6 +5151,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000342> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000342> "WBls:0000342"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000342> "231 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000342> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000342> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000342> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000341>))
 
@@ -4860,6 +5164,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000343> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000343> "WBls:0000343"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000343> "232 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000343> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000343> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000343> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000342>))
 
@@ -4872,6 +5177,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000344> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000344> "WBls:0000344"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000344> "233 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000344> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000344> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000344> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000343>))
 
@@ -4884,6 +5190,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000345> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000345> "WBls:0000345"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000345> "234 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000345> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000345> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000345> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000344>))
 
@@ -4896,6 +5203,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000346> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000346> "WBls:0000346"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000346> "235 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000346> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000346> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000346> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000345>))
 
@@ -4908,6 +5216,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000347> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000347> "WBls:0000347"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000347> "236 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000347> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000347> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000347> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000346>))
 
@@ -4920,6 +5229,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000348> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000348> "WBls:0000348"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000348> "237 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000348> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000348> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000348> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000347>))
 
@@ -4932,6 +5242,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000349> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000349> "WBls:0000349"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000349> "238 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000349> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000349> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000349> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000348>))
 
@@ -4944,6 +5255,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000350> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000350> "WBls:0000350"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000350> "239 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000350> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000350> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000350> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000349>))
 
@@ -4956,6 +5268,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000351> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000351> "WBls:0000351"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000351> "240 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000351> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000351> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000351> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000350>))
 
@@ -4968,6 +5281,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000352> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000352> "WBls:0000352"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000352> "241 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000352> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000352> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000352> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000351>))
 
@@ -4980,6 +5294,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000353> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000353> "WBls:0000353"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000353> "242 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000353> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000353> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000353> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000352>))
 
@@ -4992,6 +5307,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000354> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000354> "WBls:0000354"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000354> "243 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000354> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000354> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000354> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000353>))
 
@@ -5004,6 +5320,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000355> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000355> "WBls:0000355"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000355> "244 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000355> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000355> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000355> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000354>))
 
@@ -5016,6 +5333,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000356> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000356> "WBls:0000356"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000356> "245 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000356> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000356> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000356> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000355>))
 
@@ -5028,6 +5346,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000357> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000357> "WBls:0000357"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000357> "246 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000357> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000357> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000357> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000356>))
 
@@ -5040,6 +5359,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000358> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000358> "WBls:0000358"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000358> "247 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000358> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000358> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000358> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000357>))
 
@@ -5052,6 +5372,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000359> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000359> "WBls:0000359"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000359> "248 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000359> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000359> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000359> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000358>))
 
@@ -5064,6 +5385,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000360> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000360> "WBls:0000360"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000360> "249 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000360> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000360> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000360> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000359>))
 
@@ -5076,6 +5398,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000361> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000361> "WBls:0000361"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000361> "250 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000361> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000361> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000361> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000360>))
 
@@ -5088,6 +5411,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000362> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000362> "WBls:0000362"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000362> "251 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000362> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000362> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000362> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000361>))
 
@@ -5100,6 +5424,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000363> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000363> "WBls:0000363"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000363> "252 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000363> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000363> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000363> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000362>))
 
@@ -5112,6 +5437,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000364> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000364> "WBls:0000364"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000364> "253 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000364> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000364> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000364> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000363>))
 
@@ -5124,6 +5450,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000365> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000365> "WBls:0000365"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000365> "254 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000365> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000365> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000365> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000364>))
 
@@ -5136,6 +5463,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000366> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000366> "WBls:0000366"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000366> "255 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000366> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000366> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000366> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000365>))
 
@@ -5148,6 +5476,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000367> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000367> "WBls:0000367"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000367> "256 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000367> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000367> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000367> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000366>))
 
@@ -5160,6 +5489,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000368> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000368> "WBls:0000368"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000368> "257 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000368> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000368> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000368> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000367>))
 
@@ -5172,6 +5502,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000369> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000369> "WBls:0000369"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000369> "258 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000369> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000369> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000369> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000368>))
 
@@ -5184,6 +5515,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000370> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000370> "WBls:0000370"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000370> "259 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000370> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000370> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000370> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000369>))
 
@@ -5196,6 +5528,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000371> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000371> "WBls:0000371"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000371> "260 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000371> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000371> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000371> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000370>))
 
@@ -5208,6 +5541,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000372> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000372> "WBls:0000372"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000372> "261 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000372> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000372> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000372> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000371>))
 
@@ -5220,6 +5554,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000373> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000373> "WBls:0000373"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000373> "262 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000373> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000373> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000373> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000372>))
 
@@ -5232,6 +5567,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000374> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000374> "WBls:0000374"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000374> "263 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000374> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000374> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000374> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000373>))
 
@@ -5244,6 +5580,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000375> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000375> "WBls:0000375"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000375> "264 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000375> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000375> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000375> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000374>))
 
@@ -5256,6 +5593,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000376> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000376> "WBls:0000376"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000376> "265 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000376> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000376> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000376> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000375>))
 
@@ -5268,6 +5606,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000377> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000377> "WBls:0000377"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000377> "266 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000377> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000377> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000377> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000376>))
 
@@ -5280,6 +5619,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000378> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000378> "WBls:0000378"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000378> "267 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000378> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000378> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000378> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000377>))
 
@@ -5292,6 +5632,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000379> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000379> "WBls:0000379"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000379> "268 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000379> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000379> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000379> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000378>))
 
@@ -5304,6 +5645,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000380> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000380> "WBls:0000380"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000380> "269 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000380> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000380> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000380> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000379>))
 
@@ -5316,6 +5658,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000381> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000381> "WBls:0000381"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000381> "270 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000381> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000381> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000381> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000380>))
 
@@ -5328,6 +5671,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000382> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000382> "WBls:0000382"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000382> "271 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000382> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000382> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000382> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000381>))
 
@@ -5340,6 +5684,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000383> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000383> "WBls:0000383"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000383> "272 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000383> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000383> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000383> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000382>))
 
@@ -5352,6 +5697,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000384> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000384> "WBls:0000384"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000384> "273 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000384> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000384> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000384> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000383>))
 
@@ -5364,6 +5710,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000385> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000385> "WBls:0000385"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000385> "274 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000385> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000385> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000385> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000384>))
 
@@ -5376,6 +5723,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000386> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000386> "WBls:0000386"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000386> "275 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000386> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000386> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000386> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000385>))
 
@@ -5388,6 +5736,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000387> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000387> "WBls:0000387"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000387> "276 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000387> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000387> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000387> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000386>))
 
@@ -5400,6 +5749,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000388> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000388> "WBls:0000388"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000388> "277 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000388> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000388> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000388> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000387>))
 
@@ -5412,6 +5762,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000389> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000389> "WBls:0000389"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000389> "278 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000389> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000389> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000389> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000388>))
 
@@ -5424,6 +5775,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000390> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000390> "WBls:0000390"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000390> "279 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000390> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000390> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000390> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000389>))
 
@@ -5436,6 +5788,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000391> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000391> "WBls:0000391"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000391> "280 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000391> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000391> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000391> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000390>))
 
@@ -5448,6 +5801,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000392> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000392> "WBls:0000392"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000392> "281 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000392> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000392> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000392> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000391>))
 
@@ -5460,6 +5814,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000393> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000393> "WBls:0000393"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000393> "282 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000393> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000393> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000393> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000392>))
 
@@ -5472,6 +5827,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000394> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000394> "WBls:0000394"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000394> "283 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000394> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000394> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000394> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000393>))
 
@@ -5484,6 +5840,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000395> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000395> "WBls:0000395"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000395> "284 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000395> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000395> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000395> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000394>))
 
@@ -5496,6 +5853,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000396> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000396> "WBls:0000396"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000396> "285 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000396> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000396> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000396> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000395>))
 
@@ -5508,6 +5866,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000397> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000397> "WBls:0000397"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000397> "286 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000397> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000397> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000397> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000396>))
 
@@ -5520,6 +5879,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000398> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000398> "WBls:0000398"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000398> "287 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000398> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000398> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000398> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000397>))
 
@@ -5532,6 +5892,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000399> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000399> "WBls:0000399"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000399> "288 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000399> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000399> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000399> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000398>))
 
@@ -5544,6 +5905,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000400> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000400> "WBls:0000400"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000400> "289 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000400> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000400> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000400> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000399>))
 
@@ -5556,6 +5918,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000401> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000401> "WBls:0000401"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000401> "290 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000401> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000401> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000010>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000401> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000400>))
 
@@ -5568,6 +5931,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000402> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000402> "WBls:0000402"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000402> "291 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000402> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000402> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000402> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000401>))
 
@@ -5580,6 +5944,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000403> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000403> "WBls:0000403"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000403> "292 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000403> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000403> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000403> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000402>))
 
@@ -5592,6 +5957,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000404> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000404> "WBls:0000404"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000404> "293 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000404> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000404> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000404> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000403>))
 
@@ -5604,6 +5970,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000405> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000405> "WBls:0000405"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000405> "294 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000405> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000405> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000405> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000404>))
 
@@ -5616,6 +5983,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000406> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000406> "WBls:0000406"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000406> "295 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000406> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000406> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000406> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000405>))
 
@@ -5628,6 +5996,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000407> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000407> "WBls:0000407"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000407> "296 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000407> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000407> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000407> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000406>))
 
@@ -5640,6 +6009,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000408> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000408> "WBls:0000408"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000408> "297 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000408> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000408> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000408> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000407>))
 
@@ -5652,6 +6022,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000409> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000409> "WBls:0000409"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000409> "298 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000409> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000409> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000409> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000408>))
 
@@ -5664,6 +6035,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000410> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000410> "WBls:0000410"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000410> "299 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000410> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000410> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000410> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000409>))
 
@@ -5676,6 +6048,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000411> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000411> "WBls:0000411"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000411> "300 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000411> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000411> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000411> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000410>))
 
@@ -5688,6 +6061,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000412> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000412> "WBls:0000412"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000412> "301 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000412> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000412> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000412> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000411>))
 
@@ -5700,6 +6074,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000413> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000413> "WBls:0000413"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000413> "302 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000413> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000413> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000413> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000412>))
 
@@ -5712,6 +6087,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000414> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000414> "WBls:0000414"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000414> "303 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000414> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000414> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000414> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000413>))
 
@@ -5724,6 +6100,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000415> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000415> "WBls:0000415"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000415> "304 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000415> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000415> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000415> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000414>))
 
@@ -5736,6 +6113,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000416> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000416> "WBls:0000416"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000416> "305 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000416> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000416> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000416> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000415>))
 
@@ -5748,6 +6126,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000417> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000417> "WBls:0000417"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000417> "306 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000417> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000417> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000417> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000416>))
 
@@ -5760,6 +6139,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000418> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000418> "WBls:0000418"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000418> "307 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000418> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000418> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000418> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000417>))
 
@@ -5772,6 +6152,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000419> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000419> "WBls:0000419"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000419> "308 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000419> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000419> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000419> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000418>))
 
@@ -5784,6 +6165,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000420> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000420> "WBls:0000420"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000420> "309 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000420> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000420> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000420> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000419>))
 
@@ -5796,6 +6178,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000421> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000421> "WBls:0000421"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000421> "310 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000421> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000421> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000421> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000420>))
 
@@ -5808,6 +6191,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000422> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000422> "WBls:0000422"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000422> "311 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000422> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000422> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000422> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000421>))
 
@@ -5820,6 +6204,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000423> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000423> "WBls:0000423"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000423> "312 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000423> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000423> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000423> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000422>))
 
@@ -5832,6 +6217,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000424> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000424> "WBls:0000424"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000424> "313 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000424> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000424> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000424> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000423>))
 
@@ -5844,6 +6230,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000425> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000425> "WBls:0000425"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000425> "314 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000425> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000425> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000425> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000424>))
 
@@ -5856,6 +6243,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000426> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000426> "WBls:0000426"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000426> "315 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000426> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000426> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000426> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000425>))
 
@@ -5868,6 +6256,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000427> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000427> "WBls:0000427"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000427> "316 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000427> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000427> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000427> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000426>))
 
@@ -5880,6 +6269,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000428> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000428> "WBls:0000428"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000428> "317 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000428> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000428> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000428> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000427>))
 
@@ -5892,6 +6282,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000429> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000429> "WBls:0000429"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000429> "318 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000429> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000429> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000429> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000428>))
 
@@ -5904,6 +6295,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000430> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000430> "WBls:0000430"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000430> "319 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000430> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000430> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000430> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000429>))
 
@@ -5916,6 +6308,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000431> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000431> "WBls:0000431"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000431> "320 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000431> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000431> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000431> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000430>))
 
@@ -5928,6 +6321,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000432> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000432> "WBls:0000432"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000432> "321 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000432> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000432> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000432> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000431>))
 
@@ -5940,6 +6334,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000433> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000433> "WBls:0000433"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000433> "322 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000433> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000433> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000433> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000432>))
 
@@ -5952,6 +6347,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000434> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000434> "WBls:0000434"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000434> "323 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000434> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000434> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000434> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000433>))
 
@@ -5964,6 +6360,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000435> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000435> "WBls:0000435"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000435> "324 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000435> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000435> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000435> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000434>))
 
@@ -5976,6 +6373,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000436> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000436> "WBls:0000436"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000436> "325 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000436> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000436> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000436> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000435>))
 
@@ -5988,6 +6386,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000437> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000437> "WBls:0000437"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000437> "326 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000437> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000437> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000437> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000436>))
 
@@ -6000,6 +6399,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000438> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000438> "WBls:0000438"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000438> "327 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000438> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000438> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000438> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000437>))
 
@@ -6012,6 +6412,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000439> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000439> "WBls:0000439"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000439> "328 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000439> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000439> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000439> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000438>))
 
@@ -6024,6 +6425,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000440> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000440> "WBls:0000440"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000440> "329 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000440> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000440> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000440> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000439>))
 
@@ -6036,6 +6438,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000441> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000441> "WBls:0000441"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000441> "330 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000441> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000441> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000441> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000440>))
 
@@ -6048,6 +6451,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000442> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000442> "WBls:0000442"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000442> "331 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000442> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000442> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000442> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000441>))
 
@@ -6060,6 +6464,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000443> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000443> "WBls:0000443"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000443> "332 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000443> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000443> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000443> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000442>))
 
@@ -6072,6 +6477,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000444> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000444> "WBls:0000444"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000444> "333 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000444> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000444> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000444> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000443>))
 
@@ -6084,6 +6490,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000445> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000445> "WBls:0000445"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000445> "334 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000445> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000445> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000445> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000444>))
 
@@ -6096,6 +6503,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000446> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000446> "WBls:0000446"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000446> "335 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000446> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000446> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000446> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000445>))
 
@@ -6108,6 +6516,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000447> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000447> "WBls:0000447"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000447> "336 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000447> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000447> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000447> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000446>))
 
@@ -6120,6 +6529,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000448> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000448> "WBls:0000448"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000448> "337 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000448> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000448> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000448> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000447>))
 
@@ -6132,6 +6542,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000449> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000449> "WBls:0000449"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000449> "338 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000449> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000449> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000449> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000448>))
 
@@ -6144,6 +6555,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000450> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000450> "WBls:0000450"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000450> "339 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000450> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000450> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000450> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000449>))
 
@@ -6156,6 +6568,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000451> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000451> "WBls:0000451"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000451> "340 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000451> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000451> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000451> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000450>))
 
@@ -6168,6 +6581,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000452> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000452> "WBls:0000452"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000452> "341 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000452> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000452> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000452> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000451>))
 
@@ -6180,6 +6594,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000453> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000453> "WBls:0000453"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000453> "342 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000453> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000453> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000453> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000452>))
 
@@ -6192,6 +6607,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000454> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000454> "WBls:0000454"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000454> "343 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000454> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000454> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000454> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000453>))
 
@@ -6204,6 +6620,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000455> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000455> "WBls:0000455"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000455> "344 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000455> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000455> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000455> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000454>))
 
@@ -6216,6 +6633,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000456> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000456> "WBls:0000456"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000456> "345 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000456> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000456> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000456> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000455>))
 
@@ -6228,6 +6646,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000457> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000457> "WBls:0000457"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000457> "346 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000457> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000457> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000457> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000456>))
 
@@ -6240,6 +6659,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000458> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000458> "WBls:0000458"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000458> "347 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000458> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000458> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000458> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000457>))
 
@@ -6252,6 +6672,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000459> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000459> "WBls:0000459"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000459> "348 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000459> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000459> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000459> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000458>))
 
@@ -6264,6 +6685,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000460> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000460> "WBls:0000460"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000460> "349 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000460> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000459>))
 
@@ -6276,6 +6698,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000461> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000461> "WBls:0000461"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000461> "350 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000461> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000461> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000013>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000461> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000460>))
 
@@ -6288,6 +6711,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000462> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000462> "WBls:0000462"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000462> "351 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000462> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000461>))
 
@@ -6300,6 +6724,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000463> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000463> "WBls:0000463"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000463> "352 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000463> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000463> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000463> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000462>))
 
@@ -6312,6 +6737,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000464> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000464> "WBls:0000464"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000464> "353 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000464> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000464> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000464> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000463>))
 
@@ -6324,6 +6750,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000465> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000465> "WBls:0000465"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000465> "354 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000465> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000465> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000465> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000464>))
 
@@ -6336,6 +6763,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000466> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000466> "WBls:0000466"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000466> "355 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000466> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000466> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000466> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000465>))
 
@@ -6348,6 +6776,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000467> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000467> "WBls:0000467"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000467> "356 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000467> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000467> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000467> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000466>))
 
@@ -6360,6 +6789,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000468> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000468> "WBls:0000468"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000468> "357 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000468> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000468> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000468> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000467>))
 
@@ -6372,6 +6802,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000469> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000469> "WBls:0000469"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000469> "358 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000469> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000469> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000469> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000468>))
 
@@ -6384,6 +6815,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000470> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000470> "WBls:0000470"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000470> "359 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000470> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000470> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000469>))
 
@@ -6396,6 +6828,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000471> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000471> "WBls:0000471"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000471> "360 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000471> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000471> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000471> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000470>))
 
@@ -6408,6 +6841,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000472> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000472> "WBls:0000472"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000472> "361 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000472> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000472> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000472> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000471>))
 
@@ -6420,6 +6854,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000473> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000473> "WBls:0000473"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000473> "362 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000473> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000473> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000473> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000472>))
 
@@ -6432,6 +6867,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000474> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000474> "WBls:0000474"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000474> "363 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000474> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000474> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000474> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000473>))
 
@@ -6444,6 +6880,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000475> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000475> "WBls:0000475"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000475> "364 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000475> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000475> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000475> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000474>))
 
@@ -6456,6 +6893,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000476> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000476> "WBls:0000476"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000476> "365 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000476> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000476> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000476> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000475>))
 
@@ -6468,6 +6906,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000477> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000477> "WBls:0000477"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000477> "366 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000477> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000477> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000477> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000476>))
 
@@ -6480,6 +6919,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000478> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000478> "WBls:0000478"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000478> "367 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000478> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000478> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000478> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000477>))
 
@@ -6492,6 +6932,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000479> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000479> "WBls:0000479"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000479> "368 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000479> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000479> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000479> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000478>))
 
@@ -6504,6 +6945,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000480> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000480> "WBls:0000480"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000480> "369 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000480> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000480> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000480> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000479>))
 
@@ -6516,6 +6958,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000481> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000481> "WBls:0000481"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000481> "370 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000481> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000481> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000481> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000480>))
 
@@ -6528,6 +6971,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000482> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000482> "WBls:0000482"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000482> "371 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000482> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000482> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000482> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000481>))
 
@@ -6540,6 +6984,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000483> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000483> "WBls:0000483"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000483> "372 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000483> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000483> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000483> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000482>))
 
@@ -6552,6 +6997,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000484> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000484> "WBls:0000484"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000484> "373 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000484> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000484> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000484> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000483>))
 
@@ -6564,6 +7010,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000485> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000485> "WBls:0000485"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000485> "374 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000485> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000485> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000485> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000484>))
 
@@ -6576,6 +7023,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000486> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000486> "WBls:0000486"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000486> "375 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000486> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000486> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000486> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000485>))
 
@@ -6588,6 +7036,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000487> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000487> "WBls:0000487"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000487> "376 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000487> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000487> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000487> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000486>))
 
@@ -6600,6 +7049,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000488> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000488> "WBls:0000488"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000488> "377 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000488> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000488> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000488> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000487>))
 
@@ -6612,6 +7062,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000489> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000489> "WBls:0000489"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000489> "378 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000489> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000489> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000489> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000488>))
 
@@ -6624,6 +7075,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000490> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000490> "WBls:0000490"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000490> "379 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000490> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000490> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000490> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000489>))
 
@@ -6636,6 +7088,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000491> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000491> "WBls:0000491"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000491> "380 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000491> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000491> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000491> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000490>))
 
@@ -6648,6 +7101,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000492> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000492> "WBls:0000492"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000492> "381 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000492> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000492> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000492> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000491>))
 
@@ -6660,6 +7114,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000493> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000493> "WBls:0000493"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000493> "382 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000493> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000493> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000493> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000492>))
 
@@ -6672,6 +7127,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000494> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000494> "WBls:0000494"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000494> "383 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000494> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000494> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000494> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000493>))
 
@@ -6684,6 +7140,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000495> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000495> "WBls:0000495"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000495> "384 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000495> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000494>))
 
@@ -6696,6 +7153,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000496> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000496> "WBls:0000496"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000496> "385 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000496> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000496> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000496> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000495>))
 
@@ -6708,6 +7166,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000497> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000497> "WBls:0000497"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000497> "386 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000497> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000497> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000497> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000496>))
 
@@ -6720,6 +7179,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000498> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000498> "WBls:0000498"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000498> "387 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000498> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000498> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000498> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000497>))
 
@@ -6732,6 +7192,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000499> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000499> "WBls:0000499"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000499> "388 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000499> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000499> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000499> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000498>))
 
@@ -6744,6 +7205,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000500> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000500> "WBls:0000500"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000500> "389 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000500> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000500> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000500> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000499>))
 
@@ -6756,6 +7218,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000501> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000501> "WBls:0000501"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000501> "390 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000501> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000501> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000501> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000500>))
 
@@ -6768,6 +7231,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000502> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000502> "WBls:0000502"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000502> "391 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000502> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000502> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000501>))
 
@@ -6780,6 +7244,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000503> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000503> "WBls:0000503"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000503> "392 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000503> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000503> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000503> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000502>))
 
@@ -6792,6 +7257,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000504> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000504> "WBls:0000504"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000504> "393 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000504> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000504> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000504> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000503>))
 
@@ -6804,6 +7270,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000505> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000505> "WBls:0000505"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000505> "394 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000505> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000505> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000505> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000504>))
 
@@ -6816,6 +7283,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000506> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000506> "WBls:0000506"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000506> "395 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000506> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000506> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000506> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000505>))
 
@@ -6828,6 +7296,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000507> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000507> "WBls:0000507"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000507> "396 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000507> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000507> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000507> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000506>))
 
@@ -6840,6 +7309,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000508> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000508> "WBls:0000508"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000508> "397 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000508> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000508> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000508> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000507>))
 
@@ -6852,6 +7322,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000509> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000509> "WBls:0000509"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000509> "398 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000509> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000509> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000508>))
 
@@ -6864,6 +7335,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000510> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000510> "WBls:0000510"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000510> "399 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000510> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000510> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000510> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000509>))
 
@@ -6876,6 +7348,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000511> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000511> "WBls:0000511"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000511> "400 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000511> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000510>))
 
@@ -6888,6 +7361,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000512> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000512> "WBls:0000512"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000512> "401 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000512> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000512> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000512> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000511>))
 
@@ -6900,6 +7374,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000513> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000513> "WBls:0000513"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000513> "402 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000513> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000513> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000513> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000512>))
 
@@ -6912,6 +7387,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000514> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000514> "WBls:0000514"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000514> "403 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000514> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000514> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000514> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000513>))
 
@@ -6924,6 +7400,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000515> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000515> "WBls:0000515"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000515> "404 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000515> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000515> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000515> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000514>))
 
@@ -6936,6 +7413,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000516> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000516> "WBls:0000516"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000516> "405 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000516> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000515>))
 
@@ -6948,6 +7426,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000517> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000517> "WBls:0000517"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000517> "406 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000517> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000517> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000517> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000516>))
 
@@ -6960,6 +7439,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000518> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000518> "WBls:0000518"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000518> "407 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000518> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000518> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000518> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000517>))
 
@@ -6972,6 +7452,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000519> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000519> "WBls:0000519"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000519> "408 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000519> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000519> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000519> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000518>))
 
@@ -6984,6 +7465,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000520> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000520> "WBls:0000520"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000520> "409 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000520> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000520> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000520> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000519>))
 
@@ -6996,6 +7478,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000521> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000521> "WBls:0000521"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000521> "410 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000521> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000521> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000521> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000520>))
 
@@ -7008,6 +7491,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000522> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000522> "WBls:0000522"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000522> "411 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000522> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000522> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000522> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000521>))
 
@@ -7020,6 +7504,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000523> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000523> "WBls:0000523"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000523> "412 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000523> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000523> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000523> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000522>))
 
@@ -7032,6 +7517,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000524> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000524> "WBls:0000524"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000524> "413 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000524> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000524> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000524> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000523>))
 
@@ -7044,6 +7530,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000525> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000525> "WBls:0000525"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000525> "414 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000525> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000525> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000525> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000524>))
 
@@ -7056,6 +7543,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000526> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000526> "WBls:0000526"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000526> "415 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000526> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000526> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000526> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000525>))
 
@@ -7068,6 +7556,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000527> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000527> "WBls:0000527"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000527> "416 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000527> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000527> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000527> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000526>))
 
@@ -7080,6 +7569,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000528> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000528> "WBls:0000528"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000528> "417 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000528> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000528> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000528> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000527>))
 
@@ -7092,6 +7582,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000529> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000529> "WBls:0000529"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000529> "418 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000529> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000529> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000529> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000528>))
 
@@ -7104,6 +7595,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000530> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000530> "WBls:0000530"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000530> "419 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000530> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000530> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000530> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000529>))
 
@@ -7116,6 +7608,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000531> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000531> "WBls:0000531"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000531> "420 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000531> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000531> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000531> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000530>))
 
@@ -7128,6 +7621,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000532> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000532> "WBls:0000532"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000532> "421 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000532> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000532> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000532> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000531>))
 
@@ -7140,6 +7634,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000533> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000533> "WBls:0000533"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000533> "422 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000533> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000533> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000533> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000532>))
 
@@ -7152,6 +7647,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000534> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000534> "WBls:0000534"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000534> "423 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000534> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000534> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000534> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000533>))
 
@@ -7164,6 +7660,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000535> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000535> "WBls:0000535"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000535> "424 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000535> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000535> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000535> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000534>))
 
@@ -7176,6 +7673,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000536> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000536> "WBls:0000536"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000536> "425 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000536> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000536> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000536> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000535>))
 
@@ -7188,6 +7686,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000537> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000537> "WBls:0000537"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000537> "426 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000537> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000537> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000537> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000536>))
 
@@ -7200,6 +7699,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000538> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000538> "WBls:0000538"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000538> "427 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000538> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000538> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000538> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000537>))
 
@@ -7212,6 +7712,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000539> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000539> "WBls:0000539"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000539> "428 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000539> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000539> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000539> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000538>))
 
@@ -7224,6 +7725,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000540> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000540> "WBls:0000540"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000540> "429 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000540> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000540> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000540> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000539>))
 
@@ -7236,6 +7738,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000541> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000541> "WBls:0000541"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000541> "430 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000541> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000541> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000541> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000540>))
 
@@ -7248,6 +7751,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000542> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000542> "WBls:0000542"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000542> "431 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000542> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000542> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000542> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000541>))
 
@@ -7260,6 +7764,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000543> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000543> "WBls:0000543"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000543> "432 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000543> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000543> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000543> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000542>))
 
@@ -7272,6 +7777,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000544> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000544> "WBls:0000544"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000544> "433 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000544> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000544> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000544> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000543>))
 
@@ -7284,6 +7790,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000545> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000545> "WBls:0000545"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000545> "434 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000545> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000545> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000545> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000544>))
 
@@ -7296,6 +7803,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000546> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000546> "WBls:0000546"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000546> "435 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000546> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000546> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000546> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000545>))
 
@@ -7308,6 +7816,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000547> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000547> "WBls:0000547"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000547> "436 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000547> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000547> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000547> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000546>))
 
@@ -7320,6 +7829,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000548> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000548> "WBls:0000548"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000548> "437 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000548> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000548> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000548> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000547>))
 
@@ -7332,6 +7842,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000549> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000549> "WBls:0000549"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000549> "438 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000549> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000549> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000549> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000548>))
 
@@ -7344,6 +7855,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000550> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000550> "WBls:0000550"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000550> "439 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000550> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000550> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000550> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000549>))
 
@@ -7356,6 +7868,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000551> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000551> "WBls:0000551"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000551> "440 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000551> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000551> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000550>))
 
@@ -7368,6 +7881,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000552> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000552> "WBls:0000552"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000552> "441 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000552> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000551>))
 
@@ -7380,6 +7894,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000553> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000553> "WBls:0000553"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000553> "442 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000553> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000553> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000553> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000552>))
 
@@ -7392,6 +7907,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000554> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000554> "WBls:0000554"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000554> "443 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000554> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000554> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000554> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000553>))
 
@@ -7404,6 +7920,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000555> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000555> "WBls:0000555"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000555> "444 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000555> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000555> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000555> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000554>))
 
@@ -7416,6 +7933,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000556> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000556> "WBls:0000556"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000556> "445 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000556> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000556> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000556> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000555>))
 
@@ -7428,6 +7946,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000557> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000557> "WBls:0000557"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000557> "446 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000557> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000557> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000557> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000556>))
 
@@ -7440,6 +7959,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000558> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000558> "WBls:0000558"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000558> "447 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000558> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000557>))
 
@@ -7452,6 +7972,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000559> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000559> "WBls:0000559"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000559> "448 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000559> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000559> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000559> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000558>))
 
@@ -7464,6 +7985,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000560> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000560> "WBls:0000560"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000560> "449 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000560> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000560> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000560> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000559>))
 
@@ -7476,6 +7998,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000561> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000561> "WBls:0000561"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000561> "450 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000561> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000561> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000561> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000560>))
 
@@ -7488,6 +8011,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000562> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000562> "WBls:0000562"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000562> "451 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000562> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000562> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000562> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000561>))
 
@@ -7500,6 +8024,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000563> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000563> "WBls:0000563"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000563> "452 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000563> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000563> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000563> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000562>))
 
@@ -7512,6 +8037,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000564> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000564> "WBls:0000564"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000564> "453 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000564> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000564> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000564> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000563>))
 
@@ -7524,6 +8050,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000565> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000565> "WBls:0000565"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000565> "454 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000565> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000565> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000565> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000564>))
 
@@ -7536,6 +8063,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000566> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000566> "WBls:0000566"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000566> "455 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000566> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000566> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000566> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000565>))
 
@@ -7548,6 +8076,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000567> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000567> "WBls:0000567"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000567> "456 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000567> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000567> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000567> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000566>))
 
@@ -7560,6 +8089,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000568> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000568> "WBls:0000568"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000568> "457 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000568> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000568> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000568> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000567>))
 
@@ -7572,6 +8102,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000569> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000569> "WBls:0000569"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000569> "458 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000569> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000569> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000569> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000568>))
 
@@ -7584,6 +8115,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000570> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000570> "WBls:0000570"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000570> "459 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000570> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000570> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000570> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000569>))
 
@@ -7596,6 +8128,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000571> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000571> "WBls:0000571"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000571> "460 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000571> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000571> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000018>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000571> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000570>))
 
@@ -7608,6 +8141,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000572> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000572> "WBls:0000572"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000572> "461 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000572> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000572> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000572> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000571>))
 
@@ -7620,6 +8154,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000573> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000573> "WBls:0000573"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000573> "462 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000573> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000573> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000573> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000572>))
 
@@ -7632,6 +8167,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000574> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000574> "WBls:0000574"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000574> "463 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000574> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000574> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000573>))
 
@@ -7644,6 +8180,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000575> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000575> "WBls:0000575"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000575> "464 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000575> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000575> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000575> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000574>))
 
@@ -7656,6 +8193,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000576> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000576> "WBls:0000576"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000576> "465 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000576> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000576> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000576> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000575>))
 
@@ -7668,6 +8206,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000577> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000577> "WBls:0000577"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000577> "466 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000577> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000577> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000577> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000576>))
 
@@ -7680,6 +8219,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000578> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000578> "WBls:0000578"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000578> "467 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000578> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000578> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000578> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000577>))
 
@@ -7692,6 +8232,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000579> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000579> "WBls:0000579"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000579> "468 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000579> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000579> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000579> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000578>))
 
@@ -7704,6 +8245,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000580> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000580> "WBls:0000580"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000580> "469 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000580> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000580> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000580> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000579>))
 
@@ -7716,6 +8258,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000581> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000581> "WBls:0000581"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000581> "470 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000581> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000581> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000581> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000580>))
 
@@ -7728,6 +8271,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000582> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000582> "WBls:0000582"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000582> "471 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000582> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000582> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000582> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000581>))
 
@@ -7740,6 +8284,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000583> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000583> "WBls:0000583"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000583> "472 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000583> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000583> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000583> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000582>))
 
@@ -7752,6 +8297,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000584> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000584> "WBls:0000584"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000584> "473 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000584> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000584> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000584> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000583>))
 
@@ -7764,6 +8310,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000585> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000585> "WBls:0000585"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000585> "474 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000585> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000585> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000585> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000584>))
 
@@ -7776,6 +8323,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000586> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000586> "WBls:0000586"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000586> "475 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000586> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000586> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000585>))
 
@@ -7788,6 +8336,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000587> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000587> "WBls:0000587"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000587> "476 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000587> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000587> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000586>))
 
@@ -7800,6 +8349,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000588> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000588> "WBls:0000588"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000588> "477 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000588> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000588> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000588> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000587>))
 
@@ -7812,6 +8362,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000589> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000589> "WBls:0000589"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000589> "478 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000589> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000589> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000589> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000588>))
 
@@ -7824,6 +8375,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000590> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000590> "WBls:0000590"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000590> "479 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000590> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000590> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000590> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000589>))
 
@@ -7836,6 +8388,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000591> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000591> "WBls:0000591"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000591> "480 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000591> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000591> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000591> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000590>))
 
@@ -7848,6 +8401,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000592> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000592> "WBls:0000592"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000592> "481 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000592> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000592> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000592> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000591>))
 
@@ -7860,6 +8414,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000593> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000593> "WBls:0000593"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000593> "482 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000593> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000593> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000593> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000592>))
 
@@ -7872,6 +8427,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000594> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000594> "WBls:0000594"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000594> "483 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000594> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000594> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000594> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000593>))
 
@@ -7884,6 +8440,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000595> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000595> "WBls:0000595"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000595> "484 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000595> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000595> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000595> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000594>))
 
@@ -7896,6 +8453,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000596> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000596> "WBls:0000596"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000596> "485 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000596> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000596> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000596> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000595>))
 
@@ -7908,6 +8466,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000597> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000597> "WBls:0000597"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000597> "486 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000597> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000597> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000597> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000596>))
 
@@ -7920,6 +8479,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000598> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000598> "WBls:0000598"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000598> "487 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000598> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000598> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000598> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000597>))
 
@@ -7932,6 +8492,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000599> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000599> "WBls:0000599"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000599> "488 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000599> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000599> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000599> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000598>))
 
@@ -7944,6 +8505,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000600> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000600> "WBls:0000600"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000600> "489 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000600> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000600> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000600> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000599>))
 
@@ -7956,6 +8518,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000601> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000601> "WBls:0000601"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000601> "490 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000601> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000601> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000601> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000600>))
 
@@ -7968,6 +8531,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000602> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000602> "WBls:0000602"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000602> "491 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000602> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000602> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000602> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000601>))
 
@@ -7980,6 +8544,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000603> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000603> "WBls:0000603"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000603> "492 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000603> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000603> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000603> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000602>))
 
@@ -7992,6 +8557,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000604> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000604> "WBls:0000604"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000604> "493 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000604> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000604> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000604> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000603>))
 
@@ -8004,6 +8570,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000605> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000605> "WBls:0000605"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000605> "494 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000605> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000605> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000605> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000604>))
 
@@ -8016,6 +8583,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000606> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000606> "WBls:0000606"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000606> "495 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000606> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000606> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000606> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000605>))
 
@@ -8028,6 +8596,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000607> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000607> "WBls:0000607"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000607> "496 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000607> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000607> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000607> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000606>))
 
@@ -8040,6 +8609,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000608> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000608> "WBls:0000608"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000608> "497 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000608> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000608> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000608> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000607>))
 
@@ -8052,6 +8622,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000609> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000609> "WBls:0000609"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000609> "498 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000609> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000609> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000609> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000608>))
 
@@ -8064,6 +8635,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000610> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000610> "WBls:0000610"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000610> "499 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000610> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000610> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000610> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000609>))
 
@@ -8076,6 +8648,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000611> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000611> "WBls:0000611"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000611> "500 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000611> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000611> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000611> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000610>))
 
@@ -8088,6 +8661,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000612> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000612> "WBls:0000612"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000612> "501 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000612> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000612> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000612> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000611>))
 
@@ -8100,6 +8674,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000613> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000613> "WBls:0000613"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000613> "502 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000613> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000613> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000613> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000612>))
 
@@ -8112,6 +8687,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000614> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000614> "WBls:0000614"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000614> "503 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000614> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000614> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000614> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000613>))
 
@@ -8124,6 +8700,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000615> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000615> "WBls:0000615"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000615> "504 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000615> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000615> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000615> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000614>))
 
@@ -8136,6 +8713,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000616> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000616> "WBls:0000616"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000616> "505 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000616> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000616> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000616> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000615>))
 
@@ -8148,6 +8726,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000617> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000617> "WBls:0000617"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000617> "506 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000617> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000617> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000617> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000616>))
 
@@ -8160,6 +8739,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000618> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000618> "WBls:0000618"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000618> "507 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000618> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000618> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000618> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000617>))
 
@@ -8172,6 +8752,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000619> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000619> "WBls:0000619"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000619> "508 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000619> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000619> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000619> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000618>))
 
@@ -8184,6 +8765,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000620> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000620> "WBls:0000620"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000620> "509 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000620> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000620> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000620> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000619>))
 
@@ -8196,6 +8778,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000621> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000621> "WBls:0000621"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000621> "510 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000621> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000621> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000621> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000620>))
 
@@ -8208,6 +8791,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000622> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000622> "WBls:0000622"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000622> "511 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000622> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000622> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000622> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000621>))
 
@@ -8220,6 +8804,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000623> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000623> "WBls:0000623"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000623> "512 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000623> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000623> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000622>))
 
@@ -8232,6 +8817,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000624> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000624> "WBls:0000624"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000624> "513 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000624> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000623>))
 
@@ -8244,6 +8830,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000625> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000625> "WBls:0000625"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000625> "514 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000625> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000625> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000625> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000624>))
 
@@ -8256,6 +8843,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000626> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000626> "WBls:0000626"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000626> "515 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000626> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000626> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000626> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000625>))
 
@@ -8268,6 +8856,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000627> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000627> "WBls:0000627"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000627> "516 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000627> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000627> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000627> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000626>))
 
@@ -8280,6 +8869,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000628> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000628> "WBls:0000628"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000628> "517 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000628> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000628> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000627>))
 
@@ -8292,6 +8882,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000629> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000629> "WBls:0000629"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000629> "518 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000629> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000629> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000629> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000628>))
 
@@ -8304,6 +8895,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000630> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000630> "WBls:0000630"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000630> "519 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000630> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000630> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000630> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000629>))
 
@@ -8316,6 +8908,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000631> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000631> "WBls:0000631"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000631> "520 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000631> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000631> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000019>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000631> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000630>))
 
@@ -8328,6 +8921,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000632> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000632> "WBls:0000632"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000632> "521 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000632> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000632> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000632> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000631>))
 
@@ -8340,6 +8934,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000633> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000633> "WBls:0000633"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000633> "522 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000633> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000633> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000633> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000632>))
 
@@ -8352,6 +8947,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000634> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000634> "WBls:0000634"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000634> "523 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000634> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000634> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000634> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000633>))
 
@@ -8364,6 +8960,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000635> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000635> "WBls:0000635"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000635> "524 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000635> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000635> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000635> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000634>))
 
@@ -8376,6 +8973,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000636> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000636> "WBls:0000636"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000636> "525 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000636> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000636> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000636> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000635>))
 
@@ -8388,6 +8986,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000637> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000637> "WBls:0000637"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000637> "526 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000637> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000637> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000637> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000636>))
 
@@ -8400,6 +8999,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000638> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000638> "WBls:0000638"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000638> "527 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000638> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000638> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000638> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000637>))
 
@@ -8412,6 +9012,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000639> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000639> "WBls:0000639"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000639> "528 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000639> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000639> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000639> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000638>))
 
@@ -8424,6 +9025,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000640> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000640> "WBls:0000640"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000640> "529 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000640> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000640> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000640> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000639>))
 
@@ -8436,6 +9038,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000641> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000641> "WBls:0000641"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000641> "530 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000641> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000641> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000641> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000640>))
 
@@ -8448,6 +9051,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000642> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000642> "WBls:0000642"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000642> "531 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000642> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000642> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000642> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000641>))
 
@@ -8460,6 +9064,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000643> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000643> "WBls:0000643"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000643> "532 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000643> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000643> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000643> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000642>))
 
@@ -8472,6 +9077,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000644> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000644> "WBls:0000644"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000644> "533 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000644> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000644> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000644> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000643>))
 
@@ -8484,6 +9090,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000645> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000645> "WBls:0000645"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000645> "534 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000645> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000645> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000645> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000644>))
 
@@ -8496,6 +9103,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000646> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000646> "WBls:0000646"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000646> "535 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000646> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000646> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000646> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000645>))
 
@@ -8508,6 +9116,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000647> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000647> "WBls:0000647"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000647> "536 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000647> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000647> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000647> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000646>))
 
@@ -8520,6 +9129,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000648> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000648> "WBls:0000648"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000648> "537 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000648> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000648> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000648> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000647>))
 
@@ -8532,6 +9142,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000649> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000649> "WBls:0000649"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000649> "538 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000649> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000649> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000649> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000648>))
 
@@ -8544,6 +9155,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000650> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000650> "WBls:0000650"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000650> "539 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000650> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000650> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000649>))
 
@@ -8556,6 +9168,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000651> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000651> "WBls:0000651"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000651> "540 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000651> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000650>))
 
@@ -8568,6 +9181,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000652> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000652> "WBls:0000652"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000652> "541 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000652> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000652> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000652> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000651>))
 
@@ -8580,6 +9194,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000653> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000653> "WBls:0000653"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000653> "542 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000653> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000653> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000653> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000652>))
 
@@ -8592,6 +9207,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000654> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000654> "WBls:0000654"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000654> "543 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000654> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000654> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000654> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000653>))
 
@@ -8604,6 +9220,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000655> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000655> "WBls:0000655"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000655> "544 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000655> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000655> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000655> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000654>))
 
@@ -8616,6 +9233,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000656> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000656> "WBls:0000656"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000656> "545 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000656> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000656> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000656> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000655>))
 
@@ -8628,6 +9246,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000657> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000657> "WBls:0000657"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000657> "546 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000657> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000657> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000657> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000656>))
 
@@ -8640,6 +9259,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000658> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000658> "WBls:0000658"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000658> "547 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000658> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000658> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000658> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000657>))
 
@@ -8652,6 +9272,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000659> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000659> "WBls:0000659"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000659> "548 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000659> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000659> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000659> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000658>))
 
@@ -8664,6 +9285,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000660> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000660> "WBls:0000660"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000660> "549 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000660> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000660> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000660> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000659>))
 
@@ -8676,6 +9298,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000661> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000661> "WBls:0000661"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000661> "550 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000661> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000661> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000661> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000660>))
 
@@ -8772,6 +9395,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000669> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000669> "WBls:0000669"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000669> "unfertilized egg Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000669> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000669> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000002>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000670> (6-days post-L4 adult hermaphrodite Ce)
@@ -8781,6 +9405,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000670> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000670> "WBls:0000670"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000670> "6-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000670> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000670> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000670> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000068>))
 
@@ -8791,6 +9416,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000671> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000671> "WBls:0000671"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000671> "7-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000671> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000671> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000671> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000670>))
 
@@ -8801,6 +9427,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000672> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000672> "WBls:0000672"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000672> "8-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000672> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000672> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000672> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000671>))
 
@@ -8811,6 +9438,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000673> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000673> "WBls:0000673"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000673> "9-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000673> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000673> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000673> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000672>))
 
@@ -8821,6 +9449,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000674> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000674> "WBls:0000674"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000674> "10-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000674> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000674> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000674> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000673>))
 
@@ -8831,6 +9460,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000675> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000675> "WBls:0000675"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000675> "15-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000675> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000675> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000675> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000800>))
 
@@ -8841,6 +9471,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000676> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000676> "WBls:0000676"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000676> "20-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000676> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000676> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000676> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000111>))
 
@@ -8930,6 +9561,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000683> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000683> "WBls:0000683"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000683> "L4.0 larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000683> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000683> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000038>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000683> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000037>))
 
@@ -8942,6 +9574,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000684> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000684> "WBls:0000684"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000684> "L4.1 larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000684> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000684> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000038>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000684> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000683>))
 
@@ -8954,6 +9587,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000685> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000685> "WBls:0000685"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000685> "L4.2 larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000685> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000685> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000038>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000685> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000684>))
 
@@ -8966,6 +9600,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000686> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000686> "WBls:0000686"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000686> "L4.3 larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000686> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000686> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000038>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000686> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000685>))
 
@@ -8978,6 +9613,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000687> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000687> "WBls:0000687"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000687> "L4.4 larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000687> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000687> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000038>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000687> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000686>))
 
@@ -8990,6 +9626,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000688> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000688> "WBls:0000688"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000688> "L4.5 larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000688> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000688> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000038>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000688> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000687>))
 
@@ -9002,6 +9639,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000689> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000689> "WBls:0000689"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000689> "L4.6 larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000689> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000689> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000038>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000689> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000688>))
 
@@ -9014,6 +9652,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000690> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000690> "WBls:0000690"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000690> "L4.7 larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000690> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000690> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000038>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000690> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000689>))
 
@@ -9026,6 +9665,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000691> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000691> "WBls:0000691"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000691> "L4.8 larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000691> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000691> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000038>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000691> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000690>))
 
@@ -9038,6 +9678,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000692> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000692> "WBls:0000692"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000692> "L4.9 larva Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000692> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000692> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000038>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000692> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000691>))
 
@@ -9050,6 +9691,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000693> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000693> "WBls:0000693"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000693> "560 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000693> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000693> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000693> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000661>))
 
@@ -9062,6 +9704,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000694> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000694> "WBls:0000694"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000694> "570 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000694> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000694> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000694> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000693>))
 
@@ -9074,6 +9717,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000695> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000695> "WBls:0000695"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000695> "640 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000695> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000695> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000695> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000694>))
 
@@ -9086,6 +9730,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000696> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000696> "WBls:0000696"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000696> "650 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000696> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000696> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000696> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000695>))
 
@@ -9098,6 +9743,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000697> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000697> "WBls:0000697"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000697> "660 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000697> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000697> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000697> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000696>))
 
@@ -9110,6 +9756,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000698> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000698> "WBls:0000698"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000698> "720 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000698> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000698> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000698> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000697>))
 
@@ -9122,6 +9769,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000699> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000699> "WBls:0000699"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000699> "770 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000699> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000699> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000699> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000698>))
 
@@ -9134,6 +9782,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000700> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000700> "WBls:0000700"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000700> "780 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000700> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000700> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000700> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000699>))
 
@@ -9146,6 +9795,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000701> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000701> "WBls:0000701"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000701> "820 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000701> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000701> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000701> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000700>))
 
@@ -9158,6 +9808,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000702> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000702> "WBls:0000702"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000702> "830 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000702> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000702> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000702> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000701>))
 
@@ -9170,6 +9821,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000703> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000703> "WBls:0000703"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000703> "850 min post first-cleavage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000703> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000703> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000703> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000702>))
 
@@ -9665,6 +10317,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000797> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000797> "WBls:0000797"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000797> "11-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000797> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000797> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000797> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000674>))
 
@@ -9677,6 +10330,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000798> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000798> "WBls:0000798"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000798> "12-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000798> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000798> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000798> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000797>))
 
@@ -9689,6 +10343,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000799> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000799> "WBls:0000799"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000799> "13-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000799> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000799> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000799> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000798>))
 
@@ -9701,6 +10356,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000800> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000800> "WBls:0000800"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000800> "14-days post-L4 adult hermaphrodite Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000800> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000800> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000057>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000800> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000799>))
 
@@ -9712,6 +10368,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date>
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000801> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000801> "WBls:0000801"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000801> "newly hatched L1 larval stage Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000801> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000801> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000023>))
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000801> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000062> <http://purl.obolibrary.org/obo/WBls_0000021>))
 
@@ -9724,6 +10381,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/WBls_0000802> "worm_development"^^xsd:string)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000802> "WBls:0000802"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000802> "L1 arrest Ce"^^xsd:string)
+SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000802> <http://purl.obolibrary.org/obo/WBls_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000802> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/WBls_0000801>))
 
 


### PR DESCRIPTION
Fixed label of WBls:0000074 from
'11-15 days post-L4 adult hermaphrodite'
to
'11-15 days post-L4 adult hermaphrodite Ce'
to be consistent with sibling terms

Fixed label of WBls:0000050 from
'L4-adult ecdysis'
to
'L4-adult ecdysis Ce'
to be consistent with sibling terms

Moved orphaned life stage terms under appropriate superclasses.