### PR TITLE
Remove sheathed_microfilaria axiom from general L1 life stage term

### DIFF
--- a/src/ontology/wbls-edit.owl
+++ b/src/ontology/wbls-edit.owl
@@ -2090,7 +2090,6 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespac
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/WBls_0000106> "WBls:0000106"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/WBls_0000106> "L1"^^xsd:string)
 SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000106> <http://purl.obolibrary.org/obo/WBls_0000105>)
-SubClassOf(<http://purl.obolibrary.org/obo/WBls_0000106> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002087> <http://purl.obolibrary.org/obo/WBls_0000110>))
 
 # Class: <http://purl.obolibrary.org/obo/WBls_0000107> (L2)
 


### PR DESCRIPTION
The issue was that the general "L1" life stage was asserted to be a subclass of:

'immediately preceded by' some 'sheathed microfilaria'

which clearly isn't true of all nematode L1 larva. I've removed this axiom. The pertinent L1 stages of specific species still have their appropriate 'microfilaria' axioms.